### PR TITLE
Revert 3.19 update due to build env solve failure.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN go mod download && env GOOS=linux GOARCH=amd64 go build -v -o ./jambon cmd/j
 #
 #################### Create main Docker image ####################
 #
-FROM ghcr.io/linuxserver/baseimage-alpine:3.19
+FROM ghcr.io/linuxserver/baseimage-alpine:3.18
 LABEL maintainer="Aterfax"
 #
 COPY --from=build-env /app /app/


### PR DESCRIPTION
This can be updated later when package support is present or when 3.18 goes out of support.

N.b. it's lardoon falling over during build, stopping at:

```
4.717 expvar
4.717 github.com/go-chi/chi/v5
4.717 github.com/alioygur/gores
4.717 net/http/pprof
4.718 github.com/go-chi/cors
4.809 github.com/go-chi/chi/v5/middleware
------
Dockerfile:27
--------------------
  25 |     WORKDIR /lardoon_build
  26 |     RUN export NODE_ENV=production && npm ci --include=dev && npm run build
  27 | >>> RUN env GOOS=linux GOARCH=amd64 go build -v -o ./lardoon cmd/lardoon/main.go && chmod +x lardoon && mv lardoon /app/lardoon
  28 |     #
  29 |     # Build Jambon
--------------------
ERROR: failed to solve: process "/bin/sh -c env GOOS=linux GOARCH=amd64 go build -v -o ./lardoon cmd/lardoon/main.go && chmod +x lardoon && mv lardoon /app/lardoon" did not complete successfully: exit code: 1
```